### PR TITLE
Crowbar test

### DIFF
--- a/patch.opam
+++ b/patch.opam
@@ -9,6 +9,7 @@ license: "ISC"
 
 depends: [
   "ocaml" {>= "4.04.2"}
+  "dune" {build}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/dune
+++ b/src/dune
@@ -2,5 +2,11 @@
  (name patch)
  (synopsis "Patch purely in OCaml")
  (public_name patch)
+ (modules patch)
  (wrapped false)
  (libraries bytes))
+
+(executable
+ (name patch_command)
+ (modules patch_command)
+ (libraries patch))

--- a/src/patch_command.ml
+++ b/src/patch_command.ml
@@ -1,0 +1,88 @@
+(** For now this command is only used for testing,
+    in particular it is not installed to the user.
+    (If we wanted to install it, it would need
+    a better name.)
+*)
+
+let usage =
+  "Simplified patch utility for single-file patches;\n
+   ./patch.exe <input-file> <unififed-diff-file> -o <output-file>"
+
+let exit_command_line_error = 1
+let exit_open_error = 2
+let exit_several_chunks = 3
+let exit_patch_failure = 4
+
+let run ~input ~diff =
+  match Patch.to_diffs diff with
+  | [] -> input
+  | _::_::_ ->
+    prerr_endline "Error: The diff contains several chunks,\n\
+                   which is not supported by this command.";
+    exit exit_several_chunks
+  | [diff] ->
+    begin match Patch.patch (Some input) diff with
+    | Error (`Msg str) ->
+      Printf.eprintf "Error during patching:\n%s\n%!" str;
+      exit exit_patch_failure
+    | Ok output -> output
+    end
+
+module IO = struct
+  let read input =
+    let rec loop buf input =
+      match input_char input with
+      | exception End_of_file -> Buffer.contents buf
+      | c -> Buffer.add_char buf c; loop buf input
+    in
+    loop (Buffer.create 80) input
+
+  let write output data =
+    String.iter (output_char output) data;
+    flush output;
+    ()
+end
+
+let () =
+  if Array.length Sys.argv = 1 then begin
+    prerr_endline usage;
+    exit 0;
+  end;
+  let input_path, diff_path, output_path = try
+      let input_path = Sys.argv.(1) in
+      let diff_path = Sys.argv.(2) in
+      let dash_o = Sys.argv.(3) in
+      let output_path = Sys.argv.(4) in
+      if dash_o <> "-o" then raise Exit;
+      input_path,
+      diff_path,
+      output_path
+    with _ ->
+      prerr_endline "Error parsing the command-line arguments";
+      prerr_endline usage;
+      prerr_newline ();
+      exit exit_command_line_error
+  in
+  let get_data path =
+    match open_in path with
+    | exception _ ->
+      Printf.eprintf "Error: unable to open file %S for reading\n%!" path;
+      exit exit_open_error
+    | input ->
+      let data = IO.read input in
+      close_in input;
+      data
+  in
+  let write_data path ~data =
+    match open_out path with
+    | exception _ ->
+      Printf.eprintf "Error: unable to open file %S for writing\n%!" path;
+      exit exit_open_error
+    | output ->
+      IO.write output data;
+      close_out output
+  in
+  let input_data = get_data input_path in
+  let diff_data = get_data diff_path in
+  let output_data = run ~input:input_data ~diff:diff_data in
+  write_data output_path ~data:output_data

--- a/test/crowbar_test.ml
+++ b/test/crowbar_test.ml
@@ -1,0 +1,98 @@
+type line = string
+type file = line list
+
+let string_of_file = String.concat ""
+
+module Printer = struct
+  open Crowbar
+  let line : line printer =
+    fun ppf line -> pp ppf "%S" line
+  let file : file printer =
+    fun ppf file -> pp ppf "%S" (String.concat "" file)
+end
+
+module Gen = struct
+  open Crowbar
+  let char : string gen =
+    map [range 25] (fun n -> String.make 1 (char_of_int (int_of_char 'a' + n)))
+  let line : line gen =
+    with_printer Printer.line @@
+    map [list char] (fun s -> String.concat "" (s @ ["\n"]))
+  let line_no_eol : line gen =
+    with_printer Printer.line @@
+    map [list char] (fun s -> String.concat "" s)
+  let file : file gen =
+    with_printer Printer.file @@
+    choose [
+      list line;
+      map [list line; line_no_eol] (fun lines line -> lines @ [line]);
+    ]
+end
+
+module IO = struct
+  let read input =
+    let rec loop buf acc input =
+      match input_char input with
+      | exception End_of_file ->
+        if Buffer.length buf = 0 then List.rev acc
+        else List.rev (Buffer.contents buf :: acc)
+      | '\n' ->
+        Buffer.add_char buf '\n';
+        let line = Buffer.contents buf in
+        Buffer.clear buf;
+        loop buf (line :: acc) input
+      | c ->
+        Buffer.add_char buf c;
+        loop buf acc input
+    in
+    loop (Buffer.create 80) [] input
+
+  let write output file =
+    List.iter (output_string output) file;
+    ()
+
+  let with_file_out file k =
+    let (path, oc) = Filename.open_temp_file "patch_crowbar" "" in
+    let clean () =
+      close_out oc;
+      Sys.remove path in
+    write oc file;
+    flush oc;
+    match k path with
+    | exception exn -> clean (); raise exn
+    | res -> clean (); res
+
+  let with_tmp k =
+    let path = Filename.temp_file "patch_crowbar_diff" "" in
+    let clean () = Sys.remove path in
+    match k path with
+    | exception exn -> clean (); raise exn
+    | res -> clean (); res
+end
+
+(** getting a system *diff* from two files *)
+let get_diffs (file1 : file) (file2 : file) : file =
+  IO.with_file_out file1 @@ fun path1 ->
+  IO.with_file_out file2 @@ fun path2 ->
+  IO.with_tmp @@ fun path_out ->
+  Printf.ksprintf (fun cmd -> ignore (Sys.command cmd))
+    "diff -u %S %S > %S" path1 path2 path_out;
+  let input = open_in path_out in
+  let res = IO.read input in
+  close_in input;
+  res
+
+let check_Patch file1 file2 =
+  match Patch.to_diffs (string_of_file (get_diffs file1 file2)) with
+  | [] -> Crowbar.check_eq (string_of_file file1) (string_of_file file2)
+  | _::_::_ -> Crowbar.fail "not a single diff!"
+  | [diff] ->
+    match Patch.patch (Some (string_of_file file1)) diff with
+    | Error (`Msg str) -> Crowbar.fail str
+    | Ok output ->
+      Crowbar.check_eq
+        ~pp:Crowbar.pp_string
+        output (string_of_file file2)
+
+let () =
+  Crowbar.(add_test ~name:"patch" [Gen.file; Gen.file] check_Patch)

--- a/test/crowbar_test.ml
+++ b/test/crowbar_test.ml
@@ -1,3 +1,55 @@
+(** USAGE:
+
+    This test works by generating two files (source and target),
+    diffing them using the system `diff -u` command,
+    applying our Patch code to the source file,
+    and checking that we get the target back.
+
+    Counter-examples will give you the source and target file.
+
+    From the root repository, run
+
+       dune exec test/crowbar_test.exe
+
+    to get quicheck-like (blackbox) fuzzing, and
+
+       mkdir -p /tmp/input
+       mkdir -p /tmp/output
+       echo foo > /tmp/input/test
+       dune build test/crowbar_test.exe
+       afl-fuzz -i /tmp/input -o /tmp/output dune exec test/crowbar_test.exe @@
+
+    for AFL-full (greybox) fuzzing.
+
+    If you find a counter-example, you can use src/patch_command
+    to reproduce the issue. For example, if the quickcheck mode tells you:
+
+    > patch: ....
+    > patch: FAIL
+    >
+    > When given the input:
+    >
+    >     ["\nx"; "\n"]
+    >
+    > the test failed:
+    >
+    >     "" != "\n"
+    >
+
+    You can run
+
+      echo -n -e "\nx" > file1
+      echo -n -e "\n" > file2
+      diff -u file1 file2 > diff
+      patch file1 diff -o file2-std-patch
+      dune exec src/patch_command.exe -- file1 diff -o file2-our-patch
+      diff file2-our-patch file2-std-patch
+      rm file1 file2 diff file2-std-patch file2-our-patch
+
+    to check for yourself.
+*)
+
+
 type line = string
 type file = line list
 

--- a/test/dune
+++ b/test/dune
@@ -1,8 +1,14 @@
 (executable
  (name test)
+ (modules test)
  (libraries patch alcotest))
 
 (alias
  (name runtest)
  (deps (source_tree data) (:< test.exe))
  (action (run %{<})))
+
+(executable
+ (name crowbar_test)
+ (modules crowbar_test)
+ (libraries patch crowbar))


### PR DESCRIPTION
I think that the quickcheck mode already produces counter-examples, for example

```
$ dune exec test/crowbar_test.exe
patch: ....        
patch: FAIL

When given the input:

    ["\nx"; "\n"]
    
the test failed:

    "" != "\n"
```

See the documentation in `crowbar_test.ml` for more usage information.