### PR TITLE
Add a ~p parameter to Patch.parse mimicking the behaviour of patch -p<num>

### DIFF
--- a/src/patch.mli
+++ b/src/patch.mli
@@ -28,12 +28,11 @@ type operation =
   | Create of string
   | Rename_only of string * string
   (** The operation of a diff: in-place [Edit], [Delete], [Create], [Rename_only].
-      The parameters to the variants are filenames. *)
+      The parameters to the variants are filenames.
+      NOTE: in a typical git diff file, [Rename_only] does not have any prefix. *)
 
-val pp_operation : git:bool -> Format.formatter -> operation -> unit
-(** [pp_operation ~git ppf op] pretty-prints the operation [op] on [ppf], If
-    [git] is true, the [git diff] style will be output (a
-    "diff --git oldfilename newfilename" line, etc). *)
+val pp_operation : Format.formatter -> operation -> unit
+(** [pp_operation ppf op] pretty-prints the operation [op] on [ppf]. *)
 
 val operation_eq : operation -> operation -> bool
 (** [operation_eq a b] is true if [a] and [b] are equal. *)
@@ -47,16 +46,18 @@ type t = {
 (** The type of a diff: an operation, a list of hunks, and information whether
     a trailing newline exists on the left and right. *)
 
-val pp : git:bool -> Format.formatter -> t -> unit
-(** [pp ~git ppf t] pretty-prints [t] on [ppf]. If [git] is true, "git diff"
-    style will be printed. *)
+val pp : Format.formatter -> t -> unit
+(** [pp ppf t] pretty-prints [t] on [ppf]. *)
 
-val pp_list : git:bool -> Format.formatter -> t list -> unit
-(** [pp ~git ppf diffs] pretty-prints [diffs] on [ppf]. If [git] is true,
-    "git diff" style will be printed. *)
+val pp_list : Format.formatter -> t list -> unit
+(** [pp ppf diffs] pretty-prints [diffs] on [ppf]. *)
 
-val parse : string -> t list
-(** [parse data] decodes [data] as a list of diffs.
+val parse : p:int -> string -> t list
+(** [parse ~p data] decodes [data] as a list of diffs.
+
+    @param p denotes the expected prefix level of the filenames.
+    For more information, see the option [-p] in your POSIX-complient
+    patch.
 
     @raise Parse_error if a filename was unable to be parsed *)
 

--- a/src/patch_command.ml
+++ b/src/patch_command.ml
@@ -6,15 +6,15 @@
 
 let usage =
   "Simplified patch utility for single-file patches;\n
-   ./patch.exe <input-file> <unififed-diff-file> -o <output-file>"
+   ./patch.exe -p<num> <input-file> <unified-diff-file> -o <output-file>"
 
 let exit_command_line_error = 1
 let exit_open_error = 2
 let exit_several_chunks = 3
 let exit_patch_failure = 4
 
-let run ~input ~diff =
-  match Patch.parse diff with
+let run ~p ~input ~diff =
+  match Patch.parse ~p diff with
   | [] -> input
   | _::_::_ ->
     prerr_endline "Error: The diff contains several chunks,\n\
@@ -48,12 +48,17 @@ let () =
     prerr_endline usage;
     exit 0;
   end;
-  let input_path, diff_path, output_path = try
-      let input_path = Sys.argv.(1) in
-      let diff_path = Sys.argv.(2) in
-      let dash_o = Sys.argv.(3) in
-      let output_path = Sys.argv.(4) in
+  let p, input_path, diff_path, output_path = try
+      let p =
+        let arg = Sys.argv.(1) in
+        String.sub arg 2 (String.length arg - 2) |> int_of_string
+      in
+      let input_path = Sys.argv.(2) in
+      let diff_path = Sys.argv.(3) in
+      let dash_o = Sys.argv.(4) in
+      let output_path = Sys.argv.(5) in
       if dash_o <> "-o" then raise Exit;
+      p,
       input_path,
       diff_path,
       output_path
@@ -84,5 +89,5 @@ let () =
   in
   let input_data = get_data input_path in
   let diff_data = get_data diff_path in
-  let output_data = run ~input:input_data ~diff:diff_data in
+  let output_data = run ~p ~input:input_data ~diff:diff_data in
   write_data output_path ~data:output_data

--- a/test/crowbar_test.ml
+++ b/test/crowbar_test.ml
@@ -136,7 +136,7 @@ let get_diffs (file1 : file) (file2 : file) : file =
 
 let check_Patch file1 file2 =
   let text_diff = string_of_file (get_diffs file1 file2) in
-  match Patch.parse text_diff with
+  match Patch.parse ~p:0 text_diff with
   | [] -> Crowbar.check_eq (string_of_file file1) (string_of_file file2)
   | _::_::_ -> Crowbar.fail "not a single diff!"
   | [diff] ->


### PR DESCRIPTION
PR on top of #20 

This is required when dealing with both git and GNU diffs. The user of the library cannot know which name was there to begin with an cannot eliminate the prefix in the filenames accordingly.

Requiring a `~p` parameter allows to give all the filenames cleanly and also to mimic the behaviour from GNU patch:
> If the header is that of a context diff, patch takes the old and new file names in the header.
> A name is ignored if it does not have enough slashes to satisfy the -pnum or  --strip=num  op‐
> tion.  The name /dev/null is also ignored.
