### PR TITLE
Fix parsing of '---' mid diff

### DIFF
--- a/src/patch.ml
+++ b/src/patch.ml
@@ -119,8 +119,6 @@ let count_to_sl_sl data =
 let sort_into_bags dir mine their m_nl t_nl str =
   if String.length str = 0 then
     None
-  else if String.is_prefix ~prefix:"---" str then
-    None
   else match String.get str 0, String.slice ~start:1 str with
     | ' ', data -> Some (`Both, (data :: mine), (data :: their), m_nl, t_nl)
     | '+', data -> Some (`Their, mine, (data :: their), m_nl, t_nl)


### PR DESCRIPTION
For example, with the following perfectly valid patch:
```
--- a	2024-03-22 20:38:14.411917871 +0000
+++ b	2024-03-22 20:04:53.409348792 +0000
@@ -1 +1 @@
----
+aaa
```
ocaml-patch wouldn't detect the change at all currently:
```
# Patch.to_diffs patch;;
- : Patch.t list =
[{Patch.operation = Patch.Rename ("a", "b");
  hunks =
   [{Patch.mine_start = 0; mine_len = 1; mine = []; their_start = 0;
     their_len = 1; their = []}];
  mine_no_nl = false; their_no_nl = false}]
```
but after this change it would work again:
```
# Patch.to_diffs patch;;
- : Patch.t list =
[{Patch.operation = Patch.Rename ("a", "b");
  hunks =
   [{Patch.mine_start = 0; mine_len = 1; mine = ["---"]; their_start = 0;
     their_len = 1; their = ["aaa"]}];
  mine_no_nl = false; their_no_nl = false}]
```