### PR TITLE
Merge Edit and Rename

### DIFF
--- a/src/patch.ml
+++ b/src/patch.ml
@@ -182,17 +182,15 @@ let rec to_hunks (mine_no_nl, their_no_nl, acc) = function
     | Some hunk, mine_no_nl, their_no_nl, rest -> to_hunks (mine_no_nl, their_no_nl, hunk :: acc) rest
 
 type operation =
-  | Edit of string
-  | Rename of string * string
+  | Edit of string * string
   | Delete of string
   | Create of string
   | Rename_only of string * string
 
 let operation_eq a b = match a, b with
-  | Edit a, Edit b
   | Delete a, Delete b
   | Create a, Create b -> String.equal a b
-  | Rename (a, a'), Rename (b, b')
+  | Edit (a, a'), Edit (b, b')
   | Rename_only (a, a'), Rename_only (b, b') -> String.equal a b && String.equal a' b'
   | _ -> false
 
@@ -211,11 +209,7 @@ let pp_operation ~git ppf op =
         (real_name `Mine mine) (real_name `Theirs their)
   in
   match op with
-  | Edit name ->
-    hdr name name ;
-    Format.fprintf ppf "--- %s\n" (real_name `Mine name) ;
-    Format.fprintf ppf "+++ %s\n" (real_name `Theirs name)
-  | Rename (old_name, new_name) ->
+  | Edit (old_name, new_name) ->
     hdr old_name new_name ;
     Format.fprintf ppf "--- %s\n" (real_name `Mine old_name) ;
     Format.fprintf ppf "+++ %s\n" (real_name `Theirs new_name)
@@ -264,7 +258,7 @@ let operation_of_strings git mine their =
   match get_filename_opt mine, get_filename_opt their with
   | None, Some n -> Create n
   | Some n, None -> Delete n
-  | Some a, Some b -> if String.equal a b then Edit a else Rename (a, b)
+  | Some a, Some b -> Edit (a, b)
   | None, None -> assert false (* ??!?? *)
 
 (* parses a list of lines to a diff.t list *)

--- a/src/patch.mli
+++ b/src/patch.mli
@@ -16,8 +16,7 @@ val pp_hunk : mine_no_nl:bool -> their_no_nl:bool -> Format.formatter -> hunk ->
     same format as [diff] does. *)
 
 type operation =
-  | Edit of string
-  | Rename of string * string
+  | Edit of string * string
   | Delete of string
   | Create of string
   | Rename_only of string * string

--- a/test/test.ml
+++ b/test/test.ml
@@ -176,7 +176,7 @@ let basic_hunks =
   let hunk1 = [ { mine_start = 0 ; mine_len = 1 ; mine = ["foo"] ;
                   their_start = 0 ; their_len = 1 ; their = ["foobar"] } ]
   in
-  let diff = { operation = Rename ("a", "b") ; hunks = hunk1 ; mine_no_nl = false ; their_no_nl = false } in
+  let diff = { operation = Edit ("a", "b") ; hunks = hunk1 ; mine_no_nl = false ; their_no_nl = false } in
   let hunk2 =
     [ { mine_start = 1 ; mine_len = 7 ; mine = [ "bar" ; "baz" ; "boo" ; "foo" ; "bar" ; "baz" ; "boo" ] ;
         their_start = 1 ; their_len = 7 ; their = [ "bar" ; "baz" ; "boo" ; "foo2" ; "bar" ; "baz" ; "boo" ] } ]
@@ -209,7 +209,7 @@ let basic_hunks =
     { mine_start = 0 ; mine_len = 1 ; mine = [ "foo" ] ;
       their_start = 0 ; their_len = 2 ; their = [ "foo" ; "foo" ] }
   ] in
-  let diff7 = { diff with operation = Rename ("a", "b") ; hunks = hunk7 } in
+  let diff7 = { diff with operation = Edit ("a", "b") ; hunks = hunk7 } in
   List.map (fun d -> [ d ])
     [
       diff ;
@@ -346,7 +346,7 @@ let multi_hunks =
   let hunk1 = [ { mine_start = 0 ; mine_len = 1 ; mine = ["bar"] ;
                   their_start = 0 ; their_len = 1 ; their = ["foobar"] } ]
   in
-  let diff1 = { operation = Rename ("foo", "bar") ; hunks = hunk1 ; mine_no_nl = false ; their_no_nl = false } in
+  let diff1 = { operation = Edit ("foo", "bar") ; hunks = hunk1 ; mine_no_nl = false ; their_no_nl = false } in
   let hunk2 =
     [ { mine_start = 0 ; mine_len = 1 ; mine = [ "baz" ] ;
         their_start = 0 ; their_len = 0 ; their = [] } ]
@@ -361,7 +361,7 @@ let multi_hunks =
     { mine_start = 0 ; mine_len = 1 ; mine = [ "foobarbaz" ] ;
       their_start = 0 ; their_len = 1 ; their = [ "foobar" ] }
   ] in
-  let diff4 = { operation = Edit "foobarbaz" ; hunks = hunk4 ;  mine_no_nl = false ; their_no_nl = false } in
+  let diff4 = { operation = Edit ("foobarbaz", "foobarbaz") ; hunks = hunk4 ;  mine_no_nl = false ; their_no_nl = false } in
   [ diff1 ; diff2 ; diff3 ; diff4 ]
 
 let multi_files = [ Some "bar" ; Some "baz" ; None ; Some "foobarbaz" ]
@@ -391,7 +391,7 @@ let regression_diff, regression_hunks =
 --- /dev/null
 +aaa
 |},
-  [ { operation = Rename ("a", "b");
+  [ { operation = Edit ("a", "b");
       hunks = [ { mine_start = 0; mine_len = 1; mine = ["-- /dev/null"];
                   their_start = 0; their_len = 1; their = ["aaa"]} ];
       mine_no_nl = false; their_no_nl = false} ]
@@ -425,11 +425,11 @@ let parse_real_diff_header file hdr () =
 let parse_real_diff_headers =
   List.map (fun (file, hdr) ->
       "parsing " ^ file ^ ".diff", `Quick, parse_real_diff_header file hdr)
-    [ "first", Patch.Rename ("first.old", "first.new") ;
+    [ "first", Patch.Edit ("first.old", "first.new") ;
       "create1", Patch.Create "a/create1" ;
       "git1", Patch.Create "git1.new" ;
       "git2", Patch.Rename_only ("git2.old", "git2.new") ;
-      "git3", Patch.Rename ("git3.old", "git3.new") ;
+      "git3", Patch.Edit ("git3.old", "git3.new") ;
       "git4", Patch.Delete "git4.old"
     ]
 


### PR DESCRIPTION
I feel like they shouldn't be separated given a diff can be an Edit or a Rename solely based on the prefix number. For example:
```
--- a/a
+++ b/a
```
would be Rename ("a/a", "b/a") but if we're applying it using `patch -p1` they're equal.