### PR TITLE
Speedup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/data/external"]
+	path = test/data/external
+	url = https://codeberg.org/kit-ty-kate/ocaml-patch-tests.git

--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ a "copy from / to" header, which I was unable to spot in the wild.
 ## Documentation
 
 The API documentation can be browsed [online](https://hannesm.github.io/patch/).
+
+## Testsuite
+
+The testsuite can be ran with a simple `dune test`, however note that to also
+test larger files, you must first make sure that the submodule is up-to-date:
+```
+git submodule update --init
+```

--- a/patch.opam
+++ b/patch.opam
@@ -14,7 +14,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "3.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "1.7.0"}
   "crowbar" {with-test}
 ]
 build: [

--- a/src/patch.ml
+++ b/src/patch.ml
@@ -269,7 +269,7 @@ let pp_operation ppf op =
     Format.fprintf ppf "--- %a\n" pp_filename no_file ;
     Format.fprintf ppf "+++ %a\n" pp_filename name
   | Rename_only (old_name, new_name) ->
-    Format.fprintf ppf "diff --git %a %a" pp_filename old_name pp_filename new_name;
+    Format.fprintf ppf "diff --git %a %a\n" pp_filename old_name pp_filename new_name;
     Format.fprintf ppf "rename from %a\n" pp_filename old_name;
     Format.fprintf ppf "rename to %a\n" pp_filename new_name
 

--- a/src/patch.ml
+++ b/src/patch.ml
@@ -369,7 +369,7 @@ let parse_one ~p data =
   | None, [] -> None
   | None, _ -> assert false
 
-let to_lines = Lib.String.cuts '\n'
+let to_lines = String.split_on_char '\n'
 
 let parse ~p data =
   let lines = to_lines data in


### PR DESCRIPTION
This unlocks parsing large diff files. I'll add tests on Monday.

The first commit alone allows `opam update` of opam-repository at `2025-01-before-archiving-phase1` to `master` to be made in < 7s (including just 0.1s of `Patch.parse`), compared to +infinity (several hours) before.