### PR TITLE
Fix Patch.diff generating malformed patch when adding a line at the end of a file that doesn't end with a newline character

### DIFF
--- a/src/patch.ml
+++ b/src/patch.ml
@@ -503,16 +503,6 @@ let diff_op operation a b =
     | [""], [] -> Some (create_diff ~mine_no_nl:false ~their_no_nl:true)
     | [], [""] -> Some (create_diff ~mine_no_nl:true ~their_no_nl:false)
     | [""], [""] -> Some (create_diff ~mine_no_nl:false ~their_no_nl:false)
-    | [a; ""], [b] when b <> "" ->
-        aux
-          ~mine_start ~mine_len:(mine_len + 1) ~mine:(a :: mine)
-          ~their_start ~their_len:(their_len + 1) ~their:(b :: their)
-          [""] []
-    | [a], [b; ""] when a <> "" ->
-        aux
-          ~mine_start ~mine_len:(mine_len + 1) ~mine:(a :: mine)
-          ~their_start ~their_len:(their_len + 1) ~their:(b :: their)
-          [] [""]
     | a::l1, ([] | [""]) ->
         aux
           ~mine_start ~mine_len:(mine_len + 1) ~mine:(a :: mine)
@@ -523,6 +513,16 @@ let diff_op operation a b =
           ~mine_start ~mine_len ~mine
           ~their_start ~their_len:(their_len + 1) ~their:(b :: their)
           l1 l2
+    | a::(_::_ as l1), [b] ->
+        aux
+          ~mine_start ~mine_len:(mine_len + 1) ~mine:(a :: mine)
+          ~their_start ~their_len:(their_len + 1) ~their:(b :: their)
+          l1 []
+    | [a], b::(_::_ as l2) ->
+        aux
+          ~mine_start ~mine_len:(mine_len + 1) ~mine:(a :: mine)
+          ~their_start ~their_len:(their_len + 1) ~their:(b :: their)
+          [] l2
     | a::l1, b::l2 when mine = [] && their = [] && String.equal a b ->
         aux
           ~mine_start:(mine_start + 1) ~mine_len ~mine

--- a/test/test.ml
+++ b/test/test.ml
@@ -1089,6 +1089,141 @@ let big_diff = [
   "parse own", `Quick, parse_own;
 ]
 
+let print_diff_mine_empty_their_no_nl () =
+  let a = {||} in
+  let b = {|aaa
+bbb
+ccc|} in
+  let expected = {|--- a
++++ b
+@@ -0,0 +1,3 @@
++aaa
++bbb
++ccc
+\ No newline at end of file
+|} in
+  let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in
+  Alcotest.(check string) __LOC__ expected actual
+
+let print_diff_mine_empty_their_nl () =
+  let a = {||} in
+  let b = {|aaa
+bbb
+ccc
+|} in
+  let expected = {|--- a
++++ b
+@@ -0,0 +1,3 @@
++aaa
++bbb
++ccc
+|} in
+  let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in
+  Alcotest.(check string) __LOC__ expected actual
+
+let print_diff_mine_no_nl_their_empty () =
+  let a = {|aaa
+bbb|} in
+  let b = {||} in
+  let expected = {|--- a
++++ b
+@@ -1,2 +0,0 @@
+-aaa
+-bbb
+\ No newline at end of file
+|} in
+  let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in
+  Alcotest.(check string) __LOC__ expected actual
+
+let print_diff_mine_nl_their_empty () =
+  let a = {|aaa
+bbb
+|} in
+  let b = {||} in
+  let expected = {|--- a
++++ b
+@@ -1,2 +0,0 @@
+-aaa
+-bbb
+|} in
+  let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in
+  Alcotest.(check string) __LOC__ expected actual
+
+let print_diff_mine_no_nl_their_no_nl () =
+  let a = {|aaa
+bbb|} in
+  let b = {|aaa
+bbb
+ccc|} in
+  let expected = {|--- a
++++ b
+@@ -3,0 +3,1 @@
+\ No newline at end of file
++ccc
+\ No newline at end of file
+|} in
+  let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in
+  Alcotest.(check string) __LOC__ expected actual
+
+let print_diff_mine_no_nl_their_nl () =
+  let a = {|aaa
+bbb|} in
+  let b = {|aaa
+bbb
+ccc
+|} in
+  let expected = {|--- a
++++ b
+@@ -3,0 +3,1 @@
+\ No newline at end of file
++ccc
+|} in
+  let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in
+  Alcotest.(check string) __LOC__ expected actual
+
+let print_diff_mine_nl_their_no_nl () =
+  let a = {|aaa
+bbb
+|} in
+  let b = {|aaa
+bbb
+ccc|} in
+  let expected = {|--- a
++++ b
+@@ -3,0 +3,1 @@
++ccc
+\ No newline at end of file
+|} in
+  let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in
+  Alcotest.(check string) __LOC__ expected actual
+
+let print_diff_mine_nl_their_nl () =
+  let a = {|aaa
+bbb
+|} in
+  let b = {|aaa
+bbb
+ccc
+|} in
+  let expected = {|--- a
++++ b
+@@ -3,0 +3,1 @@
++ccc
+|} in
+  let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in
+  Alcotest.(check string) __LOC__ expected actual
+
+let diff_print = [
+  "mine empty their no-nl", `Quick, print_diff_mine_empty_their_no_nl;
+  "mine empty their nl", `Quick, print_diff_mine_empty_their_nl;
+  "mine no-nl their empty", `Quick, print_diff_mine_no_nl_their_empty;
+  "mine nl their empty", `Quick, print_diff_mine_nl_their_empty;
+  "mine no-nl their no-nl", `Quick, print_diff_mine_no_nl_their_no_nl;
+  "mine no-nl their nl", `Quick, print_diff_mine_no_nl_their_nl;
+  "mine nl their no-nl", `Quick, print_diff_mine_nl_their_no_nl;
+  "mine nl their nl", `Quick, print_diff_mine_nl_their_nl;
+]
+
 let tests = [
   "parse", parse_diffs ;
   "apply", apply_diffs ;
@@ -1101,6 +1236,7 @@ let tests = [
   "patch -p", patch_p;
   "pretty-print filenames", pp_filenames;
   "big diff", big_diff;
+  "diff and print", diff_print;
 ]
 
 let () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -1157,8 +1157,10 @@ bbb
 ccc|} in
   let expected = {|--- a
 +++ b
-@@ -3,0 +3,1 @@
+@@ -2,1 +2,2 @@
+-bbb
 \ No newline at end of file
++bbb
 +ccc
 \ No newline at end of file
 |} in
@@ -1174,8 +1176,10 @@ ccc
 |} in
   let expected = {|--- a
 +++ b
-@@ -3,0 +3,1 @@
+@@ -2,1 +2,2 @@
+-bbb
 \ No newline at end of file
++bbb
 +ccc
 |} in
   let actual = Format.asprintf "%a" Patch.pp (Option.get (Patch.diff (Some ("a", a)) (Some ("b", b)))) in


### PR DESCRIPTION
Fix #28 

~TODO: add a test~