### PR TITLE
Allow to use Patch.patch and Patch.pp_hunk on large diffs with OCaml 4

### DIFF
--- a/src/lib.ml
+++ b/src/lib.ml
@@ -57,4 +57,12 @@ module List = struct
     | [] -> invalid_arg "List.last"
     | [x] -> x
     | _::xs -> last xs
+
+  let rev_cut idx l =
+    let rec aux acc idx = function
+      | l when idx = 0 -> (acc, l)
+      | [] -> invalid_arg "List.cut"
+      | x::xs -> aux (x :: acc) (idx - 1) xs
+    in
+    aux [] idx l
 end

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -9,4 +9,5 @@ end
 
 module List : sig
   val last : 'a list -> 'a
+  val rev_cut : int -> 'a list -> 'a list * 'a list
 end

--- a/src/patch.ml
+++ b/src/patch.ml
@@ -46,7 +46,10 @@ let rec apply_hunk ~cleanly ~fuzz (last_matched_line, offset, lines) ({mine_star
     if actual_mine <> (mine : string list) then
       invalid_arg "unequal mine";
     (* TODO: should we check their_len against List.length their? *)
-    (mine_start + mine_len, offset + (their_len - mine_len), List.rev_append rev_prefix (their @ suffix))
+    (mine_start + mine_len, offset + (their_len - mine_len),
+     (* TODO: Replace rev_append (rev ...) by the tail-rec when patch
+        requires OCaml >= 4.14 *)
+     List.rev_append rev_prefix (List.rev_append (List.rev their) suffix))
   in
   try patch_match ~search_offset:0
   with Invalid_argument _ ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -1106,7 +1106,7 @@ let big_diff = [
   "print", `Quick, print_big;
   "parse own", `Quick, parse_own;
   "1_000_000 print", `Quick, one_mil_print;
-  "1_000_000 apply", `Quick, (fun () -> Alcotest.match_raises "[Temporary] Stack overflow" (function Stack_overflow -> true | _ -> false) one_mil_apply);
+  "1_000_000 apply", `Quick, one_mil_apply;
 ]
 
 let print_diff_mine_empty_their_no_nl () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -1105,7 +1105,7 @@ let big_diff = [
   "parse", `Quick, parse_big;
   "print", `Quick, print_big;
   "parse own", `Quick, parse_own;
-  "1_000_000 print", `Quick, (fun () -> Alcotest.match_raises "[Temporary] Stack overflow" (function Stack_overflow -> true | _ -> false) one_mil_print);
+  "1_000_000 print", `Quick, one_mil_print;
   "1_000_000 apply", `Quick, (fun () -> Alcotest.match_raises "[Temporary] Stack overflow" (function Stack_overflow -> true | _ -> false) one_mil_apply);
 ]
 


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6513
Queued on top of #29 
Part of the patches are ported from #24 

`(@)` and `List.map` are not tail-recursive with OCaml < 5.1

~TODO: add tests~