### PR TITLE
fix: ---/+++ should take precedence over spurious git metadata

### DIFF
--- a/src/patch.ml
+++ b/src/patch.ml
@@ -425,8 +425,8 @@ let parse_one ~p data =
     | x::y::xs when Lib.String.is_prefix ~prefix:"--- " x && Lib.String.is_prefix ~prefix:"+++ " y ->
         begin match git_action, operation_of_strings ~p x y with
         | None, op -> Some op, xs
-        | Some (f, _, Delete_only), (Delete f' as op)
-        | Some (_, f, Create_only), (Create f' as op)
+        | Some (f, _, Delete_only), (Delete f' | Edit (f', _) as op)
+        | Some (_, f, Create_only), (Create f' | Edit (_, f') as op)
           when String.equal f f' -> Some op, xs
         | Some (a, b, Rename_only (_, _)), (Edit (a', b') as op)
           when String.equal a a' && String.equal b b' -> Some op, xs

--- a/test/test.ml
+++ b/test/test.ml
@@ -1013,12 +1013,42 @@ let p0_p1_root = {|\
 let p0_root = operations ~p:0 [Patch.Edit ("/a/test", "/b/test")] p0_p1_root
 let p1_root = operations ~p:1 [Patch.Edit ("a/test", "b/test")] p0_p1_root
 
+let spurious_new_file_mode = {|\
+diff --git a/dir/baz.ml b/dir/baz.ml
+new file mode 100644
+index b69a69a5a..ea988f6bd 100644
+--- a/dir/baz.ml
++++ b/dir/baz.ml
+@@ -1 +1 @@
+-This is wrong
++This is right
+|}
+
+let spurious_new_file_mode =
+  operations ~p:1 [Patch.Edit ("dir/baz.ml", "dir/baz.ml")] spurious_new_file_mode
+
+let spurious_deleted_file_mode = {|\
+diff --git a/foo.ml b/foo.ml
+deleted file mode 100644
+index b69a69a5a..ea988f6bd 100644
+--- a/foo.ml
++++ b/foo.ml
+@@ -1 +1 @@
+-This is wrong
++This is right
+|}
+
+let spurious_deleted_file_mode =
+  operations ~p:1 [Patch.Edit ("foo.ml", "foo.ml")] spurious_deleted_file_mode
+
 let patch_p = [
   "-p1", `Quick, p1;
   "-p2", `Quick, p2;
   "-p1 with adjacent slashes", `Quick, p1_adjacent_slashes;
   "-p0 with root files", `Quick, p0_root;
   "-p1 with root files", `Quick, p1_root;
+  "spurious new file mode", `Quick, spurious_new_file_mode;
+  "spurious deleted file mode", `Quick, spurious_deleted_file_mode;
 ]
 
 let pp_output_test = Alcotest.testable Format.pp_print_string String.equal


### PR DESCRIPTION
In the first commit we introduce some new tests which contain patches with git metadata that doesn't match the ---/+++ lines. In hand-edited patches, this is not an irregular occurrence and currently the patch library fails in a silly way.

The second commit fixes this by preferring the ---/+++ for deciding what kind of patch we have. This fixes the tests in the first commit.

This issue was discovered and worked around when working on vendoring this library in Dune:
- https://github.com/ocaml/dune/pull/14177 

---

Edit: These have been squashed and revised now.

When a patch contains git metadata (e.g. "new file mode" or "deleted
file mode") but the ---/+++ headers indicate an Edit with a matching
filename, accept the Edit operation from ---/+++. GNU patch similarly
ignores the spurious git metadata in this case.

Previously, these patterns only matched exact Delete/Create operations
from ---/+++. Now they also match Edit, which arises in hand-edited
patches where the git metadata is wrong but the diff hunks are valid.

